### PR TITLE
Add .gitignore for backup and untracked directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Ignore WordPress backups
+*.wpress
+public_html/wp-content/ai1wm-backups/
+public_html/thetripdealers/wp-content/ai1wm-backups/
+
+# Ignore thetripdealers and learn directories
+/thetripdealers/
+/learn/


### PR DESCRIPTION
## Summary
- ignore WordPress backup files
- exclude `thetripdealers` and `learn` directories from tracking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870754e798c832eab3104bc681ea1ac