### PR TITLE
Add Twilio call and SMS buttons

### DIFF
--- a/public_html/wp-content/plugins/fluent-crm/app/Functions/helpers.php
+++ b/public_html/wp-content/plugins/fluent-crm/app/Functions/helpers.php
@@ -1125,6 +1125,13 @@ function fluentcrm_get_crm_profile_html($userIdOrEmail, $checkPermission = true,
                             style="color: #56960b; border-color: #d9e7c9; border-radius: 3px;"><?php _e('Lifetime Value', 'fluent-crm'); ?>: <?php echo esc_html($lifeTimeValue); ?></span>
                     </div>
                 <?php endif; ?>
+                <?php if (!empty($profile->phone)): ?>
+                    <p>
+                        <?php echo esc_html($profile->phone); ?>
+                        <a href="#" class="fcrm_sms_button" data-phone="<?php echo esc_attr($profile->phone); ?>">SMS</a>
+                        <a href="tel:<?php echo esc_attr($profile->phone); ?>" class="fcrm_call_button">Call</a>
+                    </p>
+                <?php endif; ?>
             </div>
             <div class="fc_tag_lists">
                 <div class="fc_stats" style="text-align: center">

--- a/public_html/wp-content/plugins/fluentcrm-twilio-buttons/fluentcrm-twilio-buttons.php
+++ b/public_html/wp-content/plugins/fluentcrm-twilio-buttons/fluentcrm-twilio-buttons.php
@@ -1,0 +1,57 @@
+<?php
+/*
+Plugin Name: FluentCRM Twilio Buttons
+Description: Adds SMS and Call buttons next to contact phone fields using Twilio.
+Version: 0.1
+*/
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function fctb_enqueue_scripts() {
+    wp_enqueue_script(
+        'fctb-js',
+        plugins_url('js/twilio-buttons.js', __FILE__),
+        array('jquery'),
+        '0.1',
+        true
+    );
+    wp_localize_script('fctb-js', 'FCTB', array(
+        'ajax_url' => admin_url('admin-ajax.php'),
+        'nonce'    => wp_create_nonce('fctb_nonce')
+    ));
+}
+add_action('admin_enqueue_scripts', 'fctb_enqueue_scripts');
+
+function fctb_send_sms() {
+    check_ajax_referer('fctb_nonce', 'nonce');
+    $phone = sanitize_text_field($_POST['phone'] ?? '');
+    if (!$phone) {
+        wp_send_json_error('no phone');
+    }
+    $settings = get_option('fctb_twilio_settings', array(
+        'sid'   => '',
+        'token' => '',
+        'from'  => ''
+    ));
+    if (!$settings['sid'] || !$settings['token'] || !$settings['from']) {
+        wp_send_json_error('twilio not configured');
+    }
+    $body = array(
+        'To'   => $phone,
+        'From' => $settings['from'],
+        'Body' => 'Test message from FluentCRM'
+    );
+    $response = wp_remote_post("https://api.twilio.com/2010-04-01/Accounts/{$settings['sid']}/Messages.json", array(
+        'body'    => $body,
+        'headers' => array(
+            'Authorization' => 'Basic ' . base64_encode($settings['sid'] . ':' . $settings['token'])
+        )
+    ));
+    if (is_wp_error($response)) {
+        wp_send_json_error($response->get_error_message());
+    }
+    wp_send_json_success();
+}
+add_action('wp_ajax_fctb_send_sms', 'fctb_send_sms');

--- a/public_html/wp-content/plugins/fluentcrm-twilio-buttons/js/twilio-buttons.js
+++ b/public_html/wp-content/plugins/fluentcrm-twilio-buttons/js/twilio-buttons.js
@@ -1,0 +1,9 @@
+jQuery(function($){
+    $(document).on('click', '.fcrm_sms_button', function(e){
+        e.preventDefault();
+        var phone = $(this).data('phone');
+        $.post(FCTB.ajax_url, {action:'fctb_send_sms', nonce:FCTB.nonce, phone:phone}, function(resp){
+            alert(resp.success ? 'SMS sent' : 'Error: ' + resp.data);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- show SMS/Call buttons beside phone in FluentCRM profiles
- create small plugin to send SMS via Twilio

## Testing
- `php -l public_html/wp-content/plugins/fluent-crm/app/Functions/helpers.php`
- `php -l public_html/wp-content/plugins/fluentcrm-twilio-buttons/fluentcrm-twilio-buttons.php`


------
https://chatgpt.com/codex/tasks/task_e_68880f2d54b4832eb0ebcb4d4bc28999