### PR TITLE
Handle missing SCRIPT_URI in Hostinger autologin script

### DIFF
--- a/public_html/learn/create_autologin_pk6yrdgoxojtb6h.php
+++ b/public_html/learn/create_autologin_pk6yrdgoxojtb6h.php
@@ -29,9 +29,20 @@ if ( ! isset( $wp_did_header ) ) {
     // Load the WordPress library.
     require_once( dirname( __FILE__ ) . '/wp-load.php' );
 
-    if ( preg_match( '/www\./', admin_url() ) && ! preg_match( '/www\.|preview-domain\.|hostingersite\./', $_SERVER['SCRIPT_URI'] ) ) {
-        $part = parse_url($_SERVER['SCRIPT_URI']);
-        $link = $part['scheme'] . '://www.' . $part['host'] . $part['path'];
+    $script_uri = $_SERVER['SCRIPT_URI'] ?? '';
+
+    if ( ! $script_uri && ! empty( $_SERVER['HTTP_HOST'] ) ) {
+        $scheme = ! empty( $_SERVER['REQUEST_SCHEME'] ) ? $_SERVER['REQUEST_SCHEME'] : ( ! empty( $_SERVER['HTTPS'] ) && 'off' !== strtolower( $_SERVER['HTTPS'] ) ? 'https' : 'http' );
+        $path   = $_SERVER['REQUEST_URI'] ?? '';
+        $script_uri = $scheme . '://' . $_SERVER['HTTP_HOST'] . $path;
+    }
+
+    if ( $script_uri && preg_match( '/www\./', admin_url() ) && ! preg_match( '/www\.|preview-domain\.|hostingersite\./', $script_uri ) ) {
+        $part   = parse_url( $script_uri );
+        $scheme = $part['scheme'] ?? 'https';
+        $host   = $part['host'] ?? '';
+        $path   = $part['path'] ?? '';
+        $link   = $scheme . '://www.' . $host . $path;
         wp_redirect( $link );
 
         exit();


### PR DESCRIPTION
## Summary
- add guards to the Hostinger autologin bootstrap so it can build a URL when `$_SERVER['SCRIPT_URI']` is unavailable
- ensure we only redirect when we have a valid script URI and avoid undefined index notices when parsing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5ea3a0bc4832e9bb917a0f55f5462